### PR TITLE
Remove URI encoding from event name

### DIFF
--- a/particle/particle.js
+++ b/particle/particle.js
@@ -303,7 +303,7 @@ module.exports = function (RED) {
 			};
 
 			if (that.evtname) {
-				options.name = encodeURIComponent(that.evtname);
+				options.name = that.evtname;
 			}
 
 			let dps = encodeURIComponent(that.devprodslug);


### PR DESCRIPTION
Remove URI encoding from event name, so event paths like `foo/bar` work.

Steps to reproduce

1. Create a SSE to monitor for an event named `foo/bar`.
2. Publish an event to `foo/bar`.

Expected results
The SSE receives the event.

Actual results
The SSE does not receive the event, because the matching is based on a URI encoded event name.